### PR TITLE
Update NPM dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abstract-leveldown": {
@@ -19,7 +19,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
       "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "~4.0.0"
       }
     },
     "acorn": {
@@ -34,7 +34,7 @@
       "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1"
+        "acorn": "^5.0.0"
       }
     },
     "acorn-node": {
@@ -43,9 +43,9 @@
       "integrity": "sha512-krFKvw/d1F17AN3XZbybIUzEY4YEPNiGo05AfP3dBlfVKrMHETKpgjpuZkSF8qDNt9UkQcqj7am8yJLseklCMg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.1",
-        "acorn-dynamic-import": "3.0.0",
-        "xtend": "4.0.1"
+        "acorn": "^5.7.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "aligned-block-file": {
@@ -53,11 +53,11 @@
       "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.3.tgz",
       "integrity": "sha512-ai/S+nZ9XMjC0ReZfq94OLGCICVBJyhNiKWmF1J+/GVZZaXtYV805plMi9obaWjfNl/QljB+VOsT+wQ7R858xA==",
       "requires": {
-        "hashlru": "2.2.1",
-        "int53": "0.2.4",
-        "mkdirp": "0.5.1",
+        "hashlru": "^2.1.0",
+        "int53": "^0.2.4",
+        "mkdirp": "^0.5.1",
         "obv": "0.0.0",
-        "uint48be": "1.0.2"
+        "uint48be": "^1.0.1"
       },
       "dependencies": {
         "obv": {
@@ -87,8 +87,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "append-batch": {
@@ -106,8 +106,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "arr-diff": {
@@ -115,7 +115,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -146,7 +146,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -170,9 +170,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -201,11 +201,6 @@
         }
       }
     },
-    "async-depth-first": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/async-depth-first/-/async-depth-first-1.0.3.tgz",
-      "integrity": "sha1-ut7eIqIqcBtxA5bGOtuctZheCiI="
-    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -231,7 +226,7 @@
       "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
       "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
       "requires": {
-        "unherit": "1.1.1"
+        "unherit": "^1.0.0"
       }
     },
     "bail": {
@@ -280,8 +275,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "blake2s": {
@@ -300,7 +295,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -309,9 +304,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "broadcast-stream": {
@@ -331,12 +326,12 @@
       "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
-        "combine-source-map": "0.8.0",
-        "defined": "1.0.0",
-        "safe-buffer": "5.1.2",
-        "through2": "2.0.3",
-        "umd": "3.0.3"
+        "JSONStream": "^1.0.3",
+        "combine-source-map": "~0.8.0",
+        "defined": "^1.0.0",
+        "safe-buffer": "^5.1.1",
+        "through2": "^2.0.0",
+        "umd": "^3.0.0"
       }
     },
     "browser-resolve": {
@@ -367,54 +362,54 @@
       "integrity": "sha512-fMES05wq1Oukts6ksGUU2TMVHHp06LyQt0SIwbXIHm7waSrQmNBZePsU0iM/4f94zbvb/wHma+D1YrdzWYnF/A==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
-        "assert": "1.4.1",
-        "browser-pack": "6.1.0",
-        "browser-resolve": "1.11.3",
-        "browserify-zlib": "0.2.0",
-        "buffer": "5.2.0",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.6.2",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.2.0",
-        "duplexer2": "0.1.4",
-        "events": "2.1.0",
-        "glob": "7.1.2",
-        "has": "1.0.3",
-        "htmlescape": "1.1.1",
-        "https-browserify": "1.0.0",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.2.0",
-        "labeled-stream-splicer": "2.0.1",
-        "mkdirp": "0.5.1",
-        "module-deps": "6.1.0",
-        "os-browserify": "0.3.0",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.1",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.6",
-        "resolve": "1.7.1",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.1.1",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "2.0.3",
-        "timers-browserify": "1.4.2",
+        "JSONStream": "^1.0.3",
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^1.11.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "^5.0.2",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.0",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^2.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.0.0",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp": "^0.5.0",
+        "module-deps": "^6.0.0",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "~0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^2.0.0",
+        "stream-http": "^2.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
         "tty-browserify": "0.0.1",
-        "url": "0.11.0",
-        "util": "0.10.4",
-        "vm-browserify": "1.1.0",
-        "xtend": "4.0.1"
+        "url": "~0.11.0",
+        "util": "~0.10.1",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "glob": {
@@ -423,12 +418,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -439,12 +434,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -453,9 +448,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -464,10 +459,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -476,8 +471,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -486,13 +481,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -501,7 +496,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "buffer": {
@@ -510,8 +505,8 @@
       "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-alloc": {
@@ -519,8 +514,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -555,8 +550,8 @@
       "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
       "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
       "requires": {
-        "bytewise-core": "1.2.3",
-        "typewise": "1.0.3"
+        "bytewise-core": "^1.2.2",
+        "typewise": "^1.0.3"
       }
     },
     "bytewise-core": {
@@ -564,7 +559,7 @@
       "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
       "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
       "requires": {
-        "typewise-core": "1.2.0"
+        "typewise-core": "^1.2"
       }
     },
     "cached-path-relative": {
@@ -588,11 +583,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "character-entities": {
@@ -625,11 +620,11 @@
       "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.10.tgz",
       "integrity": "sha512-CbU1ISGiB2JBV6PDXx7hkl8D94d2TPD1BANUMFbr8rZYKJi8De2d3Hu2XDIOLAhXf+8yhoFOdjtLG6fxz3QByQ==",
       "requires": {
-        "is-electron": "2.1.0",
-        "sodium-browserify": "1.2.4",
-        "sodium-browserify-tweetnacl": "0.2.3",
-        "sodium-chloride": "1.1.0",
-        "sodium-native": "2.2.1"
+        "is-electron": "^2.0.0",
+        "sodium-browserify": "^1.2.4",
+        "sodium-browserify-tweetnacl": "^0.2.2",
+        "sodium-chloride": "^1.1.0",
+        "sodium-native": "^2.1.6"
       }
     },
     "chloride-test": {
@@ -637,7 +632,7 @@
       "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
       "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
       "requires": {
-        "json-buffer": "2.0.11"
+        "json-buffer": "^2.0.11"
       }
     },
     "chokidar": {
@@ -645,14 +640,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -666,8 +662,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "class-list": {
@@ -683,46 +679,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
-        "restore-cursor": "1.0.1"
-      }
-    },
-    "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-      "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
+        "restore-cursor": "^1.0.1"
       }
     },
     "co": {
@@ -746,10 +703,10 @@
       "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.6.2",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.5.7"
+        "convert-source-map": "~1.1.0",
+        "inline-source-map": "~0.6.0",
+        "lodash.memoize": "~3.0.3",
+        "source-map": "~0.5.3"
       }
     },
     "commander": {
@@ -767,10 +724,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "console-browserify": {
@@ -779,7 +736,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -798,9 +755,9 @@
       "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
       "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
       "requires": {
-        "continuable": "1.2.0",
-        "continuable-para": "1.2.0",
-        "continuable-series": "1.2.0"
+        "continuable": "~1.2.0",
+        "continuable-para": "~1.2.0",
+        "continuable-series": "~1.2.0"
       }
     },
     "continuable": {
@@ -813,7 +770,7 @@
       "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
       "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
       "requires": {
-        "continuable": "1.1.8"
+        "continuable": "~1.1.6"
       },
       "dependencies": {
         "continuable": {
@@ -828,7 +785,7 @@
       "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
       "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
       "requires": {
-        "continuable": "1.1.8"
+        "continuable": "~1.1.6"
       },
       "dependencies": {
         "continuable": {
@@ -843,8 +800,8 @@
       "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
       "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
       "requires": {
-        "continuable-hash": "0.1.4",
-        "continuable-list": "0.1.6"
+        "continuable-hash": "~0.1.4",
+        "continuable-list": "~0.1.5"
       }
     },
     "continuable-series": {
@@ -863,19 +820,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "cosine-similarity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cosine-similarity/-/cosine-similarity-1.0.1.tgz",
-      "integrity": "sha1-6V9gNlKNpG+8tK/CFWr5peKyVzI="
-    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -884,11 +836,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.5"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -897,12 +849,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       },
       "dependencies": {
         "sha.js": {
@@ -911,8 +863,8 @@
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -922,9 +874,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -933,17 +885,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "dataurl-": {
@@ -965,11 +917,6 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-    },
     "decent-ws": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/decent-ws/-/decent-ws-1.0.4.tgz",
@@ -980,7 +927,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "1.0.1"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-equal": {
@@ -998,7 +945,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-3.0.0.tgz",
       "integrity": "sha512-ajbXqRPMXRlcdyt0TuWqknOJkp1JgQjGB7xOl2V+ebol7/U11E9h3/nCZAtN1M7djmAJEIhypCUc1tIWxdQAuQ==",
       "requires": {
-        "abstract-leveldown": "4.0.3"
+        "abstract-leveldown": "~4.0.0"
       }
     },
     "define-properties": {
@@ -1006,8 +953,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.12"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -1026,10 +973,10 @@
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "2.0.3"
+        "JSONStream": "^1.0.3",
+        "shasum": "^1.0.0",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0"
       }
     },
     "des.js": {
@@ -1038,8 +985,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detab": {
@@ -1047,7 +994,7 @@
       "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
       "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.5.2"
       }
     },
     "detect-libc": {
@@ -1061,9 +1008,9 @@
       "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2",
-        "defined": "1.0.0",
-        "minimist": "1.2.0"
+        "acorn-node": "^1.3.0",
+        "defined": "^1.0.0",
+        "minimist": "^1.1.1"
       }
     },
     "diff": {
@@ -1077,9 +1024,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -1094,7 +1041,7 @@
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "ed2curve": {
@@ -1102,7 +1049,7 @@
       "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
       "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "0.x.x"
       }
     },
     "elegant-spinner": {
@@ -1116,13 +1063,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.5",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emoji-named-characters": {
@@ -1135,7 +1082,7 @@
       "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
       "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
       "requires": {
-        "emoji-named-characters": "1.0.2"
+        "emoji-named-characters": "~1.0.2"
       }
     },
     "encoding-down": {
@@ -1143,10 +1090,10 @@
       "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-4.0.1.tgz",
       "integrity": "sha512-AlSE+ugBIpLL0i9if2SlnOZ4oWj/XvBb8tw2Ie/pFB73vdYs5O/6plRyqIgjbZbz8onaL20AAuMP87LWbP56IQ==",
       "requires": {
-        "abstract-leveldown": "4.0.3",
-        "level-codec": "8.0.0",
-        "level-errors": "1.1.2",
-        "xtend": "4.0.1"
+        "abstract-leveldown": "^4.0.0",
+        "level-codec": "^8.0.0",
+        "level-errors": "^1.0.4",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "level-codec": {
@@ -1161,7 +1108,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "epidemic-broadcast-trees": {
@@ -1169,8 +1116,8 @@
       "resolved": "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-6.3.3.tgz",
       "integrity": "sha512-yNbiNBGgX69SleCvOeNL9v7DlqtcEeH6FXZOnGCSgsgcJIZQIMwsQ1HB/j7h+yvnYYh/qqX2iFP9fqR0aukuug==",
       "requires": {
-        "inherits": "2.0.3",
-        "push-stream": "10.0.3"
+        "inherits": "^2.0.3",
+        "push-stream": "^10.0.0"
       }
     },
     "errno": {
@@ -1178,7 +1125,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "es-abstract": {
@@ -1186,11 +1133,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -1198,9 +1145,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "escape-string-regexp": {
@@ -1220,22 +1167,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exit-hook": {
@@ -1248,7 +1181,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1256,7 +1189,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
@@ -1284,13 +1217,8 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
-    },
-    "extract-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/extract-object/-/extract-object-1.0.0.tgz",
-      "integrity": "sha1-G6uJ1xcRJAXgsCltoAA0h518nE0="
     },
     "fast-future": {
       "version": "1.0.2",
@@ -1307,19 +1235,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "3.0.0",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
-    },
-    "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "requires": {
-        "locate-path": "2.0.0"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "flumecodec": {
@@ -1327,7 +1247,7 @@
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
       "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
       "requires": {
-        "level-codec": "6.2.0"
+        "level-codec": "^6.2.0"
       }
     },
     "flumedb": {
@@ -1335,12 +1255,12 @@
       "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.4.9.tgz",
       "integrity": "sha512-z932cCXHteJXKcwoev8/RfJ9tQ10FeRCZ6Jh55UnxN/ayZraYZvNYObl8ujbho7xQZB1CDt2WTHCN5gEYGBqGw==",
       "requires": {
-        "cont": "1.0.3",
-        "explain-error": "1.0.4",
+        "cont": "^1.0.3",
+        "explain-error": "^1.0.3",
         "obv": "0.0.1",
         "pull-cont": "0.0.0",
-        "pull-looper": "1.0.0",
-        "pull-stream": "3.6.8"
+        "pull-looper": "^1.0.0",
+        "pull-stream": "^3.5.0"
       }
     },
     "flumelog-offset": {
@@ -1348,17 +1268,17 @@
       "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.3.1.tgz",
       "integrity": "sha512-4yYdr8tTL0qOkKqhxAxvNnIwDBaBcLEsJWbyc2wU4Ycaewts9xxcBaxNbORp2KBbTwFaqZAV13HVpfZcO1X/AA==",
       "requires": {
-        "aligned-block-file": "1.1.3",
-        "append-batch": "0.0.1",
-        "explain-error": "1.0.4",
-        "hashlru": "2.2.1",
-        "int53": "0.2.4",
-        "looper": "4.0.0",
-        "ltgt": "2.2.1",
+        "aligned-block-file": "^1.1.2",
+        "append-batch": "^0.0.1",
+        "explain-error": "^1.0.3",
+        "hashlru": "^2.2.0",
+        "int53": "^0.2.4",
+        "looper": "^4.0.0",
+        "ltgt": "^2.1.3",
         "obv": "0.0.1",
-        "pull-cursor": "3.0.0",
-        "pull-looper": "1.0.0",
-        "uint48be": "1.0.2"
+        "pull-cursor": "^3.0.0",
+        "pull-looper": "^1.0.0",
+        "uint48be": "^1.0.1"
       },
       "dependencies": {
         "looper": {
@@ -1373,10 +1293,10 @@
       "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.4.tgz",
       "integrity": "sha512-4L52hBelX7dYVAQQ9uPjksqxOCxLwI4NsfEG/+sTM423axT2Poq5cnfdvGm3HzmNowzwDIKtdy429r6PbfKEIw==",
       "requires": {
-        "async-single": "1.0.5",
-        "atomic-file": "1.1.5",
+        "async-single": "^1.0.5",
+        "atomic-file": "^1.1.3",
         "obv": "0.0.1",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.6.0"
       },
       "dependencies": {
         "atomic-file": {
@@ -1391,16 +1311,16 @@
       "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.5.tgz",
       "integrity": "sha512-LKW+YdJGemOo7TnUwpFHq4cBBiYAIKtWk+G2CK7zrxbCIiAHemBRudohBOUKuSUZZ0CReR5fJ73peBHW02VerA==",
       "requires": {
-        "charwise": "3.0.1",
-        "explain-error": "1.0.4",
-        "level": "3.0.2",
-        "ltgt": "2.2.1",
-        "mkdirp": "0.5.1",
+        "charwise": "^3.0.1",
+        "explain-error": "^1.0.4",
+        "level": "^3.0.1",
+        "ltgt": "^2.1.3",
+        "mkdirp": "^0.5.1",
         "obv": "0.0.0",
-        "pull-level": "2.0.4",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "pull-write": "1.1.4"
+        "pull-level": "^2.0.3",
+        "pull-paramap": "^1.2.1",
+        "pull-stream": "^3.5.0",
+        "pull-write": "^1.1.1"
       },
       "dependencies": {
         "obv": {
@@ -1415,13 +1335,13 @@
       "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.2.0.tgz",
       "integrity": "sha512-tq7rD63gixBDOPegw10khz/d5Bnq9qW9IbURHbWuJkG5CUBm3JP4QQSIF/Phl99jz66MRuXoXjRrXXQLN89iNQ==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "flumeview-level": "3.0.5",
-        "map-filter-reduce": "3.1.0",
+        "deep-equal": "^1.0.1",
+        "flumeview-level": "^3.0.0",
+        "map-filter-reduce": "^3.0.7",
         "pull-flatmap": "0.0.1",
-        "pull-paramap": "1.2.2",
+        "pull-paramap": "^1.1.3",
         "pull-sink-through": "0.0.0",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.4.0"
       },
       "dependencies": {
         "map-filter-reduce": {
@@ -1429,10 +1349,10 @@
           "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.1.0.tgz",
           "integrity": "sha512-os2GlG1lEWRSAvAb9iqfapQ0I1GRXSA+alSjQl0DB7XxNyDx2/VOVAEVhK7EMsqwDDCWNTBSstoo1roc7U5H0w==",
           "requires": {
-            "binary-search": "1.3.4",
+            "binary-search": "^1.2.0",
             "pull-sink-through": "0.0.0",
-            "pull-stream": "3.6.8",
-            "typewiselite": "1.0.0"
+            "pull-stream": "^3.4.3",
+            "typewiselite": "^1.0.0"
           }
         }
       }
@@ -1442,13 +1362,13 @@
       "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.13.tgz",
       "integrity": "sha512-QN/07+ia3uXpfy8/xWjLI2XGIG67Aiwp9VaOTIqYt6NHP6OfdGfl8nGRPkJRHlkfFbzEouRvJcQBFohWEXMdNQ==",
       "requires": {
-        "async-single": "1.0.5",
-        "atomic-file": "1.1.5",
-        "deep-equal": "1.0.1",
+        "async-single": "^1.0.5",
+        "atomic-file": "^1.1.3",
+        "deep-equal": "^1.0.1",
         "flumecodec": "0.0.0",
         "obv": "0.0.0",
-        "pull-notify": "0.1.1",
-        "pull-stream": "3.6.8"
+        "pull-notify": "^0.1.1",
+        "pull-stream": "^3.5.0"
       },
       "dependencies": {
         "atomic-file": {
@@ -1461,7 +1381,7 @@
           "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
           "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
           "requires": {
-            "level-codec": "6.2.0"
+            "level-codec": "^6.2.0"
           }
         },
         "obv": {
@@ -1476,10 +1396,10 @@
       "resolved": "https://registry.npmjs.org/flumeview-search/-/flumeview-search-1.0.4.tgz",
       "integrity": "sha512-iHg3sfqiRAaRU1K+Ir1TGWMDLGxO6ztLl2RFKMYJsojruk+RbcIQjktjxJ4Pzi1igrZsNYDFMOQXoLtyuQgakg==",
       "requires": {
-        "flumeview-level": "3.0.5",
-        "pull-paramap": "1.2.2",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.8"
+        "flumeview-level": "^3.0.4",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.0.1"
       }
     },
     "for-each": {
@@ -1487,7 +1407,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.4"
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -1500,22 +1420,13 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
-      }
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -1527,29 +1438,486 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "get-assigned-identifiers": {
@@ -1557,25 +1925,6 @@
       "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
       "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
       "dev": true
-    },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-    },
-    "ginga": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/ginga/-/ginga-3.0.4.tgz",
-      "integrity": "sha1-TcvbhP4jFJeINCeU073AjRHuwuY=",
-      "requires": {
-        "is-generator-function": "1.0.7",
-        "raco": "3.2.7"
-      }
     },
     "github-from-package": {
       "version": "0.0.0",
@@ -1587,11 +1936,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -1599,8 +1948,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -1608,7 +1957,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globby": {
@@ -1616,12 +1965,12 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
       "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "6.0.4",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^6.0.1",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -1634,15 +1983,7 @@
       "resolved": "https://registry.npmjs.org/graphreduce/-/graphreduce-3.0.4.tgz",
       "integrity": "sha1-v0QtCoeOg5AeXvPmUtI/+1uDHtc=",
       "requires": {
-        "statistics": "3.3.0"
-      }
-    },
-    "group-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/group-stream/-/group-stream-2.0.1.tgz",
-      "integrity": "sha1-1aHwJmN4Kpz4+KshzbHr4j0Hrcs=",
-      "requires": {
-        "through2": "2.0.3"
+        "statistics": "^3.3.0"
       }
     },
     "has": {
@@ -1650,7 +1991,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-ansi": {
@@ -1658,7 +1999,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-network": {
@@ -1677,8 +2018,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -1687,8 +2028,8 @@
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "hashlru": {
@@ -1701,23 +2042,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
       "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
     },
-    "highland": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/highland/-/highland-2.13.0.tgz",
-      "integrity": "sha512-zGZBcgAHPY2Zf9VG9S5IrlcC7CH9ELioXVtp9T5bU2a4fP2zIsA+Y8pV/n/h2lMwbWMHTX0I0xN0ODJ3Pd3aBQ==",
-      "requires": {
-        "util-deprecate": "1.0.2"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.5",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoox": {
@@ -1735,7 +2068,7 @@
       "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.2.0.tgz",
       "integrity": "sha1-w8H/iMJh23TQr2OR7vkMNG+QBzA=",
       "requires": {
-        "class-list": "0.1.1"
+        "class-list": "~0.1.1"
       }
     },
     "htmlescape": {
@@ -1768,8 +2101,8 @@
       "resolved": "https://registry.npmjs.org/hyperloadmore/-/hyperloadmore-1.1.0.tgz",
       "integrity": "sha1-qlSZJphU6IER3MMUyh8mOYZwiKM=",
       "requires": {
-        "hyperscript": "2.0.2",
-        "pull-read-queue": "1.0.3"
+        "hyperscript": "^2.0.2",
+        "pull-read-queue": "^1.0.1"
       }
     },
     "hyperscript": {
@@ -1778,8 +2111,8 @@
       "integrity": "sha1-ODnLpFVUvf4nu4HCFC0WhPgTWvU=",
       "requires": {
         "browser-split": "0.0.0",
-        "class-list": "0.1.1",
-        "html-element": "2.2.0"
+        "class-list": "~0.1.0",
+        "html-element": "^2.0.0"
       }
     },
     "hyperscroll": {
@@ -1787,13 +2120,8 @@
       "resolved": "https://registry.npmjs.org/hyperscroll/-/hyperscroll-1.0.0.tgz",
       "integrity": "sha1-eiXXKy93cX+28a5wb1Szc4aIamE=",
       "requires": {
-        "hyperscript": "2.0.2"
+        "hyperscript": "^2.0.2"
       }
-    },
-    "idb-wrapper": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
-      "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
     },
     "ieee754": {
       "version": "1.1.12",
@@ -1812,8 +2140,8 @@
       "integrity": "sha1-iEqPDxgDlZf7wnjOf07iiFD69GM=",
       "dev": true,
       "requires": {
-        "optimist": "0.6.1",
-        "through2": "0.4.2"
+        "optimist": "~0.6.0",
+        "through2": "^0.4.1"
       },
       "dependencies": {
         "isarray": {
@@ -1834,10 +2162,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1852,8 +2180,8 @@
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -1862,7 +2190,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -1877,8 +2205,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1897,7 +2225,7 @@
       "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "~0.5.3"
       }
     },
     "insert-module-globals": {
@@ -1906,27 +2234,22 @@
       "integrity": "sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
-        "acorn-node": "1.5.2",
-        "combine-source-map": "0.8.0",
-        "concat-stream": "1.6.2",
-        "is-buffer": "1.1.6",
-        "path-is-absolute": "1.0.1",
-        "process": "0.11.10",
-        "through2": "2.0.3",
-        "undeclared-identifiers": "1.1.2",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "acorn-node": "^1.5.2",
+        "combine-source-map": "^0.8.0",
+        "concat-stream": "^1.6.1",
+        "is-buffer": "^1.1.0",
+        "path-is-absolute": "^1.0.1",
+        "process": "~0.11.0",
+        "through2": "^2.0.0",
+        "undeclared-identifiers": "^1.1.2",
+        "xtend": "^4.0.0"
       }
     },
     "int53": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
       "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
-    },
-    "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
     "ip": {
       "version": "1.1.5",
@@ -1948,8 +2271,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "1.0.2",
-        "is-decimal": "1.0.2"
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-binary-path": {
@@ -1957,7 +2280,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -1995,7 +2318,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -2013,20 +2336,15 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
-    },
-    "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw=="
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-hexadecimal": {
@@ -2039,7 +2357,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-posix-bracket": {
@@ -2057,13 +2375,8 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -2084,11 +2397,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isbuffer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/isbuffer/-/isbuffer-0.0.0.tgz",
-      "integrity": "sha1-OMFG2d9Si4v5sHAcPUPPEt8/w5s="
     },
     "isexe": {
       "version": "2.0.0",
@@ -2114,7 +2422,7 @@
       "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "jsonify": {
@@ -2134,7 +2442,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "labeled-stream-splicer": {
@@ -2143,9 +2451,9 @@
       "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "isarray": "2.0.4",
-        "stream-splicer": "2.0.0"
+        "inherits": "^2.0.1",
+        "isarray": "^2.0.4",
+        "stream-splicer": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -2156,22 +2464,14 @@
         }
       }
     },
-    "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
-    },
     "level": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/level/-/level-3.0.2.tgz",
       "integrity": "sha512-2qYbbiptPsPWGUI+AgB1gTNXqIjPpALRqrQyNx1zWYNZxhhuzEj/IE4Unu9weEBnsUEocfYe56xOGlAceb8/Fg==",
       "requires": {
-        "level-packager": "2.1.1",
-        "leveldown": "3.0.2",
-        "opencollective-postinstall": "2.0.0"
+        "level-packager": "^2.0.2",
+        "leveldown": "^3.0.0",
+        "opencollective-postinstall": "^2.0.0"
       }
     },
     "level-codec": {
@@ -2184,7 +2484,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.2.tgz",
       "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
@@ -2192,52 +2492,9 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.3.tgz",
       "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
-      }
-    },
-    "level-js": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
-      "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
-      "requires": {
-        "abstract-leveldown": "0.12.4",
-        "idb-wrapper": "1.7.2",
-        "isbuffer": "0.0.0",
-        "ltgt": "2.2.1",
-        "typedarray-to-buffer": "1.0.4",
-        "xtend": "2.1.2"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-          "requires": {
-            "xtend": "3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "0.4.0"
-          }
-        }
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.5",
+        "xtend": "^4.0.0"
       }
     },
     "level-packager": {
@@ -2245,8 +2502,8 @@
       "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-2.1.1.tgz",
       "integrity": "sha512-6l3G6dVkmdvHwOJrEA9d9hL6SSFrzwjQoLP8HsvohOgfY/8Z9LyTKNCM5Gc84wtsUWCuIHu6r+S6WrCtTWUJCw==",
       "requires": {
-        "encoding-down": "4.0.1",
-        "levelup": "2.0.2"
+        "encoding-down": "~4.0.0",
+        "levelup": "^2.0.0"
       }
     },
     "level-post": {
@@ -2254,7 +2511,7 @@
       "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
       "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
-        "ltgt": "2.2.1"
+        "ltgt": "^2.1.2"
       }
     },
     "level-sublevel": {
@@ -2262,14 +2519,14 @@
       "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
       "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
       "requires": {
-        "bytewise": "1.1.0",
-        "levelup": "0.19.1",
-        "ltgt": "2.1.3",
-        "pull-defer": "0.2.2",
-        "pull-level": "2.0.4",
-        "pull-stream": "3.6.8",
-        "typewiselite": "1.0.0",
-        "xtend": "4.0.1"
+        "bytewise": "~1.1.0",
+        "levelup": "~0.19.0",
+        "ltgt": "~2.1.1",
+        "pull-defer": "^0.2.2",
+        "pull-level": "^2.0.3",
+        "pull-stream": "^3.6.8",
+        "typewiselite": "~1.0.0",
+        "xtend": "~4.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -2277,7 +2534,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
-            "xtend": "3.0.0"
+            "xtend": "~3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -2292,7 +2549,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "requires": {
-            "readable-stream": "1.0.34"
+            "readable-stream": "~1.0.26"
           }
         },
         "deferred-leveldown": {
@@ -2300,7 +2557,7 @@
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
           "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
           "requires": {
-            "abstract-leveldown": "0.12.4"
+            "abstract-leveldown": "~0.12.1"
           }
         },
         "isarray": {
@@ -2313,13 +2570,13 @@
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
           "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
           "requires": {
-            "bl": "0.8.2",
-            "deferred-leveldown": "0.2.0",
-            "errno": "0.1.7",
-            "prr": "0.0.0",
-            "readable-stream": "1.0.34",
-            "semver": "5.1.1",
-            "xtend": "3.0.0"
+            "bl": "~0.8.1",
+            "deferred-leveldown": "~0.2.0",
+            "errno": "~0.1.1",
+            "prr": "~0.0.0",
+            "readable-stream": "~1.0.26",
+            "semver": "~5.1.0",
+            "xtend": "~3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -2344,10 +2601,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "semver": {
@@ -2362,122 +2619,16 @@
         }
       }
     },
-    "level-transactions": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/level-transactions/-/level-transactions-2.1.4.tgz",
-      "integrity": "sha1-tDLlb/7GxDoi0YwDJT/17VW6igs=",
-      "requires": {
-        "abstract-leveldown": "2.7.2",
-        "async-depth-first": "1.0.3",
-        "errno": "0.1.7",
-        "functional-red-black-tree": "1.0.1",
-        "levelup": "1.3.9",
-        "stream-iterate": "1.2.0",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-              "requires": {
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.7"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "leveldown": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
       "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
       "requires": {
-        "abstract-leveldown": "4.0.3",
-        "bindings": "1.3.0",
-        "fast-future": "1.0.2",
-        "nan": "2.10.0",
-        "prebuild-install": "4.0.0"
+        "abstract-leveldown": "~4.0.0",
+        "bindings": "~1.3.0",
+        "fast-future": "~1.0.2",
+        "nan": "~2.10.0",
+        "prebuild-install": "^4.0.0"
       }
     },
     "levelup": {
@@ -2485,162 +2636,10 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.2.tgz",
       "integrity": "sha512-us+nTLUyd/eLnclYYddOCdAVw1hnymGx/9p4Jr5ThohStsjLqMVmbYiz6/SYFZEPXNF+AKQSvh6fA2e2KZpC8w==",
       "requires": {
-        "deferred-leveldown": "3.0.0",
-        "level-errors": "1.1.2",
-        "level-iterator-stream": "2.0.3",
-        "xtend": "4.0.1"
-      }
-    },
-    "levi": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/levi/-/levi-2.1.7.tgz",
-      "integrity": "sha1-lboB0VwqZ8U/ccotzU21N9276Hw=",
-      "requires": {
-        "cosine-similarity": "1.0.1",
-        "extract-object": "1.0.0",
-        "ginga": "3.0.4",
-        "group-stream": "2.0.1",
-        "highland": "2.13.0",
-        "level-js": "2.2.4",
-        "level-transactions": "2.1.4",
-        "leveldown": "1.9.0",
-        "levelup": "1.3.9",
-        "sorted-merge-stream": "1.0.1",
-        "stemmer": "0.1.4",
-        "stream-iterate": "1.2.0",
-        "sublevelup": "4.0.0",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "2.6.3",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-              "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-              "requires": {
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.7"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "leveldown": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.9.0.tgz",
-          "integrity": "sha512-3MwcrnCUIuFiKp/jSrG1UqDTV4k1yH8f5HH6T9dpqCKG+lRxcfo2KwAqbzTT+TTKfCbaATeHMy9mm1y6sI3ZvA==",
-          "requires": {
-            "abstract-leveldown": "2.7.2",
-            "bindings": "1.3.0",
-            "fast-future": "1.0.2",
-            "nan": "2.7.0",
-            "prebuild-install": "2.5.3"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "nan": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-          "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
-        },
-        "prebuild-install": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-          "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-          "requires": {
-            "detect-libc": "1.0.3",
-            "expand-template": "1.1.1",
-            "github-from-package": "0.0.0",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "node-abi": "2.4.3",
-            "noop-logger": "0.1.1",
-            "npmlog": "4.1.2",
-            "os-homedir": "1.0.2",
-            "pump": "2.0.1",
-            "rc": "1.2.8",
-            "simple-get": "2.8.1",
-            "tar-fs": "1.16.3",
-            "tunnel-agent": "0.6.0",
-            "which-pm-runs": "1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
+        "deferred-leveldown": "~3.0.0",
+        "level-errors": "~1.1.0",
+        "level-iterator-stream": "~2.0.0",
+        "xtend": "~4.0.0"
       }
     },
     "libnested": {
@@ -2659,15 +2658,6 @@
       "integrity": "sha512-dw5Jh6TZ5qc5rQVZe3JrSO/J05CE+DmAPnqD7Q2glBUE969xZ6o3fchnUxyPlp6ss3x0MFxmdJntveFN+XTg1g==",
       "requires": {
         "libsodium": "0.7.3"
-      }
-    },
-    "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
       }
     },
     "lodash.get": {
@@ -2696,7 +2686,7 @@
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.0.0"
       }
     },
     "log-update": {
@@ -2704,8 +2694,8 @@
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
+        "ansi-escapes": "^1.0.0",
+        "cli-cursor": "^1.0.2"
       }
     },
     "longest-streak": {
@@ -2723,8 +2713,8 @@
       "resolved": "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.3.tgz",
       "integrity": "sha1-Vi4qkgPYZh9g6HEt5Af72t8nXck=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "tape": "4.9.1"
+        "mkdirp": "^0.5.1",
+        "tape": "^4.6.3"
       }
     },
     "lru-cache": {
@@ -2732,8 +2722,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "ltgt": {
@@ -2746,10 +2736,10 @@
       "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
       "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
       "requires": {
-        "binary-search": "1.3.4",
+        "binary-search": "^1.2.0",
         "pull-sink-through": "0.0.0",
-        "pull-stream": "3.6.8",
-        "typewiselite": "1.0.0"
+        "pull-stream": "^3.3.0",
+        "typewiselite": "^1.0.0"
       }
     },
     "map-merge": {
@@ -2773,8 +2763,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "mdmanifest": {
@@ -2782,18 +2772,10 @@
       "resolved": "https://registry.npmjs.org/mdmanifest/-/mdmanifest-1.0.8.tgz",
       "integrity": "sha1-wEiRiDwoyDYC4dBrBaEQN+NZtMg=",
       "requires": {
-        "minimist": "1.2.0",
-        "remark": "3.2.3",
-        "remark-html": "2.0.2",
-        "word-wrap": "1.2.3"
-      }
-    },
-    "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "requires": {
-        "mimic-fn": "1.2.0"
+        "minimist": "^1.2.0",
+        "remark": "^3.2.2",
+        "remark-html": "^2.0.2",
+        "word-wrap": "^1.1.0"
       }
     },
     "micromatch": {
@@ -2801,19 +2783,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -2822,14 +2804,9 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -2853,7 +2830,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2882,21 +2859,21 @@
       "integrity": "sha512-NPs5N511VD1rrVJihSso/LiBShRbJALYBKzDW91uZYy7BpjnO4bGnZL3HjZ9yKcFdZUWwaYjDz9zxbuP7vKMuQ==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.3",
-        "browser-resolve": "1.11.3",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.6.2",
-        "defined": "1.0.0",
-        "detective": "5.1.0",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.6",
-        "resolve": "1.7.1",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
+        "JSONStream": "^1.0.3",
+        "browser-resolve": "^1.7.0",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "~1.6.0",
+        "defined": "^1.0.0",
+        "detective": "^5.0.2",
+        "duplexer2": "^0.1.2",
+        "inherits": "^2.0.1",
+        "parents": "^1.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.4.0",
+        "stream-combiner2": "^1.1.1",
+        "subarg": "^1.0.0",
+        "through2": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "monotonic-timestamp": {
@@ -2914,22 +2891,22 @@
       "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.0.tgz",
       "integrity": "sha1-4oTV5KlE5yS+4uOJbLMAfwaaQbs=",
       "requires": {
-        "blake2s": "1.0.1",
-        "cont": "1.0.3",
-        "explain-error": "1.0.4",
-        "mkdirp": "0.5.1",
-        "pull-cat": "1.1.11",
-        "pull-defer": "0.2.2",
-        "pull-file": "0.5.0",
-        "pull-glob": "1.0.7",
-        "pull-live": "1.0.1",
-        "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "pull-write-file": "0.2.4",
-        "rc": "0.5.5",
-        "rimraf": "2.2.8",
-        "stream-to-pull-stream": "1.7.2"
+        "blake2s": "~1.0.1",
+        "cont": "~1.0.1",
+        "explain-error": "~1.0.1",
+        "mkdirp": "~0.5.0",
+        "pull-cat": "^1.1.8",
+        "pull-defer": "^0.2.2",
+        "pull-file": "^0.5.0",
+        "pull-glob": "~1.0.6",
+        "pull-live": "^1.0.0",
+        "pull-notify": "^0.1.1",
+        "pull-paramap": "^1.2.2",
+        "pull-stream": "^3.6.2",
+        "pull-write-file": "^0.2.1",
+        "rc": "~0.5.4",
+        "rimraf": "~2.2.8",
+        "stream-to-pull-stream": "^1.7.2"
       },
       "dependencies": {
         "deep-extend": {
@@ -2947,7 +2924,7 @@
           "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "requires": {
-            "pull-utf8-decoder": "1.0.2"
+            "pull-utf8-decoder": "^1.0.2"
           }
         },
         "rc": {
@@ -2955,10 +2932,10 @@
           "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
           "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
           "requires": {
-            "deep-extend": "0.2.11",
-            "ini": "1.3.5",
-            "minimist": "0.0.10",
-            "strip-json-comments": "0.1.3"
+            "deep-extend": "~0.2.5",
+            "ini": "~1.3.0",
+            "minimist": "~0.0.7",
+            "strip-json-comments": "0.1.x"
           }
         },
         "rimraf": {
@@ -2978,8 +2955,8 @@
       "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.4.2.tgz",
       "integrity": "sha512-hVaXryaqJ3vvKjRNcOCEadzgO99nR+haxlptswr3vRvgavbK/Y/I7/Nat12WIQno2/A8+nkbE+ZcrsN3UDbtQw==",
       "requires": {
-        "pull-stream": "3.6.8",
-        "stream-to-pull-stream": "1.7.2"
+        "pull-stream": "^3.4.3",
+        "stream-to-pull-stream": "^1.7.0"
       }
     },
     "multicb": {
@@ -2992,13 +2969,13 @@
       "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.12.0.tgz",
       "integrity": "sha512-vyoVDqxiJabvepIKYN2+lYcPDcV5/de54kWXg1nYa1VK0NMJZ+gVIS6bLnQ9FmNzOxpCmVrVOkaQ0pMlMic5Ow==",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8",
-        "pull-ws": "3.3.1",
-        "secret-handshake": "1.1.13",
+        "pull-cat": "~1.1.5",
+        "pull-stream": "^3.6.1",
+        "pull-ws": "^3.3.0",
+        "secret-handshake": "^1.1.12",
         "separator-escape": "0.0.0",
         "socks": "1.1.9",
-        "stream-to-pull-stream": "1.7.2"
+        "stream-to-pull-stream": "^1.7.2"
       }
     },
     "muxrpc": {
@@ -3006,11 +2983,11 @@
       "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.0.tgz",
       "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
       "requires": {
-        "explain-error": "1.0.4",
-        "packet-stream": "2.0.4",
-        "packet-stream-codec": "1.1.2",
-        "pull-goodbye": "0.0.2",
-        "pull-stream": "3.6.8"
+        "explain-error": "^1.0.1",
+        "packet-stream": "~2.0.0",
+        "packet-stream-codec": "^1.1.1",
+        "pull-goodbye": "~0.0.1",
+        "pull-stream": "^3.2.3"
       }
     },
     "muxrpc-validation": {
@@ -3018,8 +2995,8 @@
       "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-2.0.1.tgz",
       "integrity": "sha1-zWUNFyAl/p0GQjCqs4ymMo3Rby8=",
       "requires": {
-        "pull-stream": "2.28.4",
-        "zerr": "1.0.4"
+        "pull-stream": "^2.28.3",
+        "zerr": "^1.0.1"
       },
       "dependencies": {
         "pull-stream": {
@@ -3027,7 +3004,7 @@
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "~1.1.0"
           }
         }
       }
@@ -3037,10 +3014,10 @@
       "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-1.1.0.tgz",
       "integrity": "sha1-Sum6mGq4JcSlwS/LccbaqB6rUVg=",
       "requires": {
-        "minimist": "1.2.0",
-        "pull-stream": "2.28.4",
-        "stream-to-pull-stream": "1.7.2",
-        "word-wrap": "1.2.3"
+        "minimist": "^1.2.0",
+        "pull-stream": "^2.28.3",
+        "stream-to-pull-stream": "^1.6.6",
+        "word-wrap": "^1.1.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -3048,7 +3025,7 @@
           "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
           "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
           "requires": {
-            "pull-core": "1.1.0"
+            "pull-core": "~1.1.0"
           }
         }
       }
@@ -3058,9 +3035,9 @@
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
       "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "requires": {
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.4.5"
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
       },
       "dependencies": {
         "rimraf": {
@@ -3068,7 +3045,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "requires": {
-            "glob": "6.0.4"
+            "glob": "^6.0.1"
           }
         }
       }
@@ -3088,7 +3065,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.4.1"
       }
     },
     "node-gyp-build": {
@@ -3102,7 +3079,7 @@
       "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
       "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
       "requires": {
-        "ip": "1.1.5"
+        "ip": "^1.1.5"
       }
     },
     "noop-logger": {
@@ -3115,7 +3092,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-uri": {
@@ -3128,17 +3105,9 @@
       "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
       "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
       "requires": {
-        "rc": "1.2.8",
-        "shellsubstitute": "1.2.0",
-        "untildify": "2.1.0"
-      }
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "2.0.1"
+        "rc": "^1.1.0",
+        "shellsubstitute": "^1.1.0",
+        "untildify": "^2.1.0"
       }
     },
     "npmlog": {
@@ -3146,10 +3115,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "number-is-nan": {
@@ -3177,8 +3146,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "observ": {
@@ -3191,7 +3160,7 @@
       "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
       "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
       "requires": {
-        "observ": "0.2.0"
+        "observ": "~0.2.0"
       }
     },
     "obv": {
@@ -3214,7 +3183,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -3232,7 +3201,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -3241,8 +3210,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -3269,16 +3238,6 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
-    "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
-      }
-    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3289,35 +3248,9 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "requires": {
-        "p-try": "1.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "requires": {
-        "p-limit": "1.3.0"
-      }
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "packet-stream": {
       "version": "2.0.4",
@@ -3329,8 +3262,8 @@
       "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
       "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
       "requires": {
-        "pull-reader": "1.3.1",
-        "pull-through": "1.0.18"
+        "pull-reader": "^1.2.4",
+        "pull-through": "^1.0.17"
       }
     },
     "pako": {
@@ -3345,7 +3278,7 @@
       "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
       "dev": true,
       "requires": {
-        "path-platform": "0.11.15"
+        "path-platform": "~0.11.15"
       }
     },
     "parse-asn1": {
@@ -3354,11 +3287,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-entities": {
@@ -3366,12 +3299,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "1.2.2",
-        "character-entities-legacy": "1.1.2",
-        "character-reference-invalid": "1.1.2",
-        "is-alphanumerical": "1.0.2",
-        "is-decimal": "1.0.2",
-        "is-hexadecimal": "1.0.2"
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-glob": {
@@ -3379,10 +3312,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "path-browserify": {
@@ -3391,20 +3324,10 @@
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -3423,11 +3346,11 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       },
       "dependencies": {
         "sha.js": {
@@ -3436,8 +3359,8 @@
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -3457,7 +3380,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "plur": {
@@ -3465,7 +3388,7 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "requires": {
-        "irregular-plurals": "1.4.0"
+        "irregular-plurals": "^1.0.0"
       }
     },
     "prebuild-install": {
@@ -3473,41 +3396,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
       "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.4.3",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.8",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
-    },
-    "prefixdown": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prefixdown/-/prefixdown-1.4.0.tgz",
-      "integrity": "sha1-sVWkP04tby3XCdqxEQW2Q/Md1D8=",
-      "requires": {
-        "abstract-leveldown": "2.7.2",
-        "stream-iterate": "1.2.0",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.7.2",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        }
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       }
     },
     "preserve": {
@@ -3520,7 +3423,7 @@
       "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
       "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
       "requires": {
-        "chloride": "2.2.10"
+        "chloride": "^2.2.1"
       }
     },
     "process": {
@@ -3550,11 +3453,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pull-abortable": {
@@ -3567,12 +3470,12 @@
       "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
       "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
       "requires": {
-        "chloride": "2.2.10",
-        "increment-buffer": "1.0.1",
-        "pull-reader": "1.3.1",
-        "pull-stream": "3.6.8",
-        "pull-through": "1.0.18",
-        "split-buffer": "1.0.0"
+        "chloride": "^2.2.7",
+        "increment-buffer": "~1.0.0",
+        "pull-reader": "^1.2.5",
+        "pull-stream": "^3.2.3",
+        "pull-through": "^1.0.18",
+        "split-buffer": "~1.0.0"
       }
     },
     "pull-cat": {
@@ -3595,9 +3498,9 @@
       "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
       "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
       "requires": {
-        "looper": "4.0.0",
-        "ltgt": "2.2.1",
-        "pull-stream": "3.6.8"
+        "looper": "^4.0.0",
+        "ltgt": "^2.2.0",
+        "pull-stream": "^3.6.0"
       },
       "dependencies": {
         "looper": {
@@ -3617,7 +3520,7 @@
       "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
       "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
       "requires": {
-        "pull-utf8-decoder": "1.0.2"
+        "pull-utf8-decoder": "^1.0.2"
       }
     },
     "pull-flatmap": {
@@ -3630,10 +3533,10 @@
       "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
       "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
       "requires": {
-        "pull-file": "0.5.0",
-        "pull-stream": "3.6.8",
-        "pull-traverse": "1.0.3",
-        "pull-write-file": "0.2.4"
+        "pull-file": "^0.5.0",
+        "pull-stream": "^3.3.0",
+        "pull-traverse": "^1.0.3",
+        "pull-write-file": "^0.2.1"
       },
       "dependencies": {
         "pull-file": {
@@ -3641,7 +3544,7 @@
           "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
           "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
           "requires": {
-            "pull-utf8-decoder": "1.0.2"
+            "pull-utf8-decoder": "^1.0.2"
           }
         }
       }
@@ -3651,8 +3554,8 @@
       "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.7.tgz",
       "integrity": "sha1-7vkV3eZEvdvqjdLgEG1USqy81cI=",
       "requires": {
-        "pull-fs": "1.1.6",
-        "pull-stream": "3.6.8"
+        "pull-fs": "~1.1.6",
+        "pull-stream": "^3.3.0"
       }
     },
     "pull-goodbye": {
@@ -3660,7 +3563,7 @@
       "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
       "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
       "requires": {
-        "pull-stream": "3.5.0"
+        "pull-stream": "~3.5.0"
       },
       "dependencies": {
         "pull-stream": {
@@ -3675,10 +3578,10 @@
       "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
       "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-pair": "1.1.0",
-        "pull-pushable": "2.2.0",
-        "pull-reader": "1.3.1"
+        "pull-cat": "^1.1.9",
+        "pull-pair": "~1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.3"
       }
     },
     "pull-hash": {
@@ -3691,8 +3594,8 @@
       "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.2.tgz",
       "integrity": "sha1-N6PW67+sKSzUNfXkgeUHTIwfrXU=",
       "requires": {
-        "pull-abortable": "4.0.0",
-        "pull-stream": "3.6.8"
+        "pull-abortable": "~4.0.0",
+        "pull-stream": "^3.4.5"
       },
       "dependencies": {
         "pull-abortable": {
@@ -3707,13 +3610,13 @@
       "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
       "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "requires": {
-        "level-post": "1.0.7",
-        "pull-cat": "1.1.11",
-        "pull-live": "1.0.1",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.8",
-        "pull-window": "2.1.4",
-        "stream-to-pull-stream": "1.7.2"
+        "level-post": "^1.0.7",
+        "pull-cat": "^1.1.9",
+        "pull-live": "^1.0.1",
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.0",
+        "pull-window": "^2.1.4",
+        "stream-to-pull-stream": "^1.7.1"
       }
     },
     "pull-live": {
@@ -3721,8 +3624,8 @@
       "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
       "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8"
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.0"
       }
     },
     "pull-looper": {
@@ -3730,7 +3633,7 @@
       "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
       "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       },
       "dependencies": {
         "looper": {
@@ -3745,7 +3648,7 @@
       "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
       "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
       "requires": {
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.4.5"
       }
     },
     "pull-more": {
@@ -3753,9 +3656,9 @@
       "resolved": "https://registry.npmjs.org/pull-more/-/pull-more-1.1.0.tgz",
       "integrity": "sha512-Lk1ZBNe/+vO8gktuXkqbJEgQ10UDfuovGhXt+s/CKDOU/PFz5kyPvsSNtztv4HCDZo9cXr514nLeavemq19bWA==",
       "requires": {
-        "libnested": "1.3.2",
-        "pull-next": "1.0.1",
-        "pull-stream": "3.6.8"
+        "libnested": "^1.3.1",
+        "pull-next": "^1.0.1",
+        "pull-stream": "^3.6.1"
       }
     },
     "pull-next": {
@@ -3768,11 +3671,11 @@
       "resolved": "https://registry.npmjs.org/pull-next-query/-/pull-next-query-1.0.0.tgz",
       "integrity": "sha512-pZuaV0A6SH5IQmCNNBKB2WSpHfzgj/lNeprLvCMVRV2Wh4zidtBvjgJrThRLOYxdZilL4z01T3pri0zroqKJcg==",
       "requires": {
-        "lodash.get": "4.4.2",
-        "lodash.merge": "4.6.1",
-        "lodash.set": "4.3.2",
-        "pull-next": "1.0.1",
-        "pull-stream": "3.6.8"
+        "lodash.get": "^4.4.2",
+        "lodash.merge": "^4.6.1",
+        "lodash.set": "^4.3.2",
+        "pull-next": "^1.0.1",
+        "pull-stream": "^3.6.8"
       }
     },
     "pull-notify": {
@@ -3780,7 +3683,7 @@
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
       "requires": {
-        "pull-pushable": "2.2.0"
+        "pull-pushable": "^2.0.0"
       }
     },
     "pull-pair": {
@@ -3793,7 +3696,7 @@
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       },
       "dependencies": {
         "looper": {
@@ -3813,9 +3716,9 @@
       "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz",
       "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
       "requires": {
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.8",
-        "statistics": "3.3.0"
+        "pull-pushable": "^2.0.0",
+        "pull-stream": "^3.4.5",
+        "statistics": "^3.3.0"
       }
     },
     "pull-pushable": {
@@ -3828,7 +3731,7 @@
       "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
       "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
       "requires": {
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.6.0"
       }
     },
     "pull-read-queue": {
@@ -3837,7 +3740,7 @@
       "integrity": "sha1-7zC8hQIObhb6AlskW8hA8/YW0LY=",
       "requires": {
         "pull-pause": "0.0.2",
-        "pull-stream": "3.6.8"
+        "pull-stream": "^3.6.1"
       }
     },
     "pull-reader": {
@@ -3850,7 +3753,7 @@
       "resolved": "https://registry.npmjs.org/pull-reconnect/-/pull-reconnect-0.0.3.tgz",
       "integrity": "sha1-U9zpzS8rmyEOiIleGfL/xnYh3J4=",
       "requires": {
-        "pull-defer": "0.2.2"
+        "pull-defer": "^0.2.2"
       }
     },
     "pull-sink-through": {
@@ -3873,7 +3776,7 @@
       "resolved": "https://registry.npmjs.org/pull-stringify/-/pull-stringify-2.0.0.tgz",
       "integrity": "sha1-Irox2pWvCIjg+1WSOLH6kVpqW2Q=",
       "requires": {
-        "defined": "1.0.0"
+        "defined": "^1.0.0"
       }
     },
     "pull-through": {
@@ -3881,7 +3784,7 @@
       "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
       "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
       "requires": {
-        "looper": "3.0.0"
+        "looper": "~3.0.0"
       }
     },
     "pull-traverse": {
@@ -3899,7 +3802,7 @@
       "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
       "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
       "requires": {
-        "looper": "2.0.0"
+        "looper": "^2.0.0"
       },
       "dependencies": {
         "looper": {
@@ -3914,9 +3817,9 @@
       "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
       "requires": {
-        "looper": "4.0.0",
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8"
+        "looper": "^4.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-stream": "^3.4.5"
       },
       "dependencies": {
         "looper": {
@@ -3936,9 +3839,9 @@
       "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz",
       "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
       "requires": {
-        "relative-url": "1.0.2",
-        "safe-buffer": "5.1.2",
-        "ws": "1.1.5"
+        "relative-url": "^1.0.2",
+        "safe-buffer": "^5.1.1",
+        "ws": "^1.1.0"
       }
     },
     "pump": {
@@ -3946,8 +3849,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "punycode": {
@@ -3966,7 +3869,7 @@
       "resolved": "https://registry.npmjs.org/push-stream-to-pull-stream/-/push-stream-to-pull-stream-1.0.1.tgz",
       "integrity": "sha512-gZe8pNlDFIi+0Ir2TeEFTpbrztLYVHvJgAjxOg8NFOcrisb9MKqIMSx+fmWMR6H/9PTZ2CwXubZlQWACKZ28Zw==",
       "requires": {
-        "pull-looper": "1.0.0"
+        "pull-looper": "^1.0.0"
       }
     },
     "querystring": {
@@ -3981,19 +3884,14 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
-    "raco": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/raco/-/raco-3.2.7.tgz",
-      "integrity": "sha512-jx628KlBD38qQWN3azydRjmAqosiDB98/p2VpuQ7hL3pF1tetutoFNjOMu+uPar5AbDNkZSpQmRF+Y3K50SXyA=="
-    },
     "randomatic": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -4014,7 +3912,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -4023,8 +3921,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "rc": {
@@ -4032,10 +3930,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "read-only-stream": {
@@ -4044,7 +3942,7 @@
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.2"
       }
     },
     "readable-stream": {
@@ -4052,13 +3950,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -4066,10 +3964,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "regex-cache": {
@@ -4077,7 +3975,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "relative-url": {
@@ -4090,37 +3988,37 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
       "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
       "requires": {
-        "camelcase": "2.1.1",
-        "ccount": "1.0.3",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "collapse-white-space": "1.0.4",
-        "commander": "2.17.1",
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "elegant-spinner": "1.0.1",
+        "camelcase": "^2.0.0",
+        "ccount": "^1.0.0",
+        "chalk": "^1.0.0",
+        "chokidar": "^1.0.5",
+        "collapse-white-space": "^1.0.0",
+        "commander": "^2.0.0",
+        "concat-stream": "^1.0.0",
+        "debug": "^2.0.0",
+        "elegant-spinner": "^1.0.0",
         "extend.js": "0.0.2",
-        "glob": "6.0.4",
-        "globby": "4.1.0",
-        "he": "0.5.0",
-        "log-update": "1.0.2",
-        "longest-streak": "1.0.0",
-        "markdown-table": "0.4.0",
-        "minimatch": "3.0.4",
-        "npm-prefix": "1.2.0",
-        "parse-entities": "1.1.2",
-        "repeat-string": "1.6.1",
-        "stringify-entities": "1.3.2",
-        "to-vfile": "1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.1",
-        "unified": "2.1.4",
-        "user-home": "2.0.0",
-        "vfile": "1.4.0",
-        "vfile-find-down": "1.0.0",
-        "vfile-find-up": "1.0.0",
-        "vfile-reporter": "1.5.0",
-        "ware": "1.3.0"
+        "glob": "^6.0.1",
+        "globby": "^4.0.0",
+        "he": "^0.5.0",
+        "log-update": "^1.0.1",
+        "longest-streak": "^1.0.0",
+        "markdown-table": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "npm-prefix": "^1.0.1",
+        "parse-entities": "^1.0.0",
+        "repeat-string": "^1.5.0",
+        "stringify-entities": "^1.0.0",
+        "to-vfile": "^1.0.0",
+        "trim": "^0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unified": "^2.0.0",
+        "user-home": "^2.0.0",
+        "vfile": "^1.1.0",
+        "vfile-find-down": "^1.0.0",
+        "vfile-find-up": "^1.0.0",
+        "vfile-reporter": "^1.5.0",
+        "ware": "^1.3.0"
       }
     },
     "remark-html": {
@@ -4128,13 +4026,13 @@
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
       "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
       "requires": {
-        "collapse-white-space": "1.0.4",
-        "detab": "1.0.2",
-        "normalize-uri": "1.1.1",
-        "object-assign": "4.1.1",
+        "collapse-white-space": "^1.0.0",
+        "detab": "^1.0.0",
+        "normalize-uri": "^1.0.0",
+        "object-assign": "^4.0.1",
         "trim": "0.0.1",
-        "trim-lines": "1.1.1",
-        "unist-util-visit": "1.4.0"
+        "trim-lines": "^1.0.0",
+        "unist-util-visit": "^1.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -4152,22 +4050,12 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-    },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
     "resolve": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "restore-cursor": {
@@ -4175,8 +4063,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "resumer": {
@@ -4184,7 +4072,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "rimraf": {
@@ -4192,7 +4080,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       },
       "dependencies": {
         "glob": {
@@ -4200,12 +4088,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -4216,8 +4104,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "safe-buffer": {
@@ -4231,62 +4119,62 @@
       "integrity": "sha512-2W3PPcm553TCChI9o3ntN2ke2Q8YT4+GPf/aaazgQfhBxmZm67gZhJWvduD3f8Uhn18SMUPHeG7Kru2w02sDFw==",
       "requires": {
         "atomic-file": "0.0.1",
-        "bash-color": "0.0.4",
-        "broadcast-stream": "0.2.2",
-        "cont": "1.0.3",
-        "cross-spawn": "5.1.0",
-        "deep-equal": "1.0.1",
-        "explain-error": "1.0.4",
+        "bash-color": "~0.0.3",
+        "broadcast-stream": "^0.2.1",
+        "cont": "~1.0.3",
+        "cross-spawn": "^5.1.0",
+        "deep-equal": "^1.0.1",
+        "explain-error": "^1.0.3",
         "has-network": "0.0.1",
-        "ip": "0.3.3",
-        "mdmanifest": "1.0.8",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "multiblob": "1.13.0",
-        "multicb": "1.2.2",
-        "multiserver": "1.12.0",
-        "muxrpc": "6.4.0",
-        "muxrpc-validation": "2.0.1",
-        "muxrpcli": "1.1.0",
-        "mv": "2.1.1",
-        "non-private-ip": "1.4.4",
-        "observ-debounce": "1.1.1",
+        "ip": "^0.3.3",
+        "mdmanifest": "^1.0.4",
+        "minimist": "^1.1.3",
+        "mkdirp": "~0.5.0",
+        "multiblob": "^1.13.0",
+        "multicb": "^1.0.0",
+        "multiserver": "^1.12.0",
+        "muxrpc": "^6.4.0",
+        "muxrpc-validation": "^2.0.0",
+        "muxrpcli": "^1.0.0",
+        "mv": "^2.1.1",
+        "non-private-ip": "^1.4.3",
+        "observ-debounce": "^1.1.1",
         "obv": "0.0.1",
         "on-change-network": "0.0.2",
-        "on-wakeup": "1.0.1",
-        "osenv": "0.1.5",
-        "pull-abortable": "4.1.1",
-        "pull-cat": "1.1.11",
-        "pull-file": "1.1.0",
+        "on-wakeup": "^1.0.0",
+        "osenv": "^0.1.5",
+        "pull-abortable": "~4.1.0",
+        "pull-cat": "~1.1.5",
+        "pull-file": "^1.0.0",
         "pull-flatmap": "0.0.1",
-        "pull-inactivity": "2.1.2",
-        "pull-level": "2.0.4",
-        "pull-many": "1.0.8",
-        "pull-next": "1.0.1",
+        "pull-inactivity": "~2.1.1",
+        "pull-level": "^2.0.2",
+        "pull-many": "~1.0.6",
+        "pull-next": "^1.0.0",
         "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-ping": "2.0.2",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.8",
-        "pull-stream-to-stream": "1.3.4",
-        "pull-stringify": "1.2.2",
-        "rimraf": "2.6.2",
-        "secret-stack": "4.1.0",
-        "secure-scuttlebutt": "18.2.0",
-        "ssb-blobs": "1.1.5",
-        "ssb-client": "4.5.7",
-        "ssb-config": "2.2.0",
-        "ssb-ebt": "5.2.2",
-        "ssb-friends": "2.4.0",
-        "ssb-keys": "7.0.16",
-        "ssb-links": "3.0.3",
-        "ssb-msgs": "5.2.0",
-        "ssb-query": "2.1.0",
-        "ssb-ref": "2.11.1",
-        "ssb-ws": "2.1.1",
-        "statistics": "3.3.0",
-        "stream-to-pull-stream": "1.7.2",
-        "zerr": "1.0.4"
+        "pull-paramap": "~1.2.1",
+        "pull-ping": "^2.0.2",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.2",
+        "pull-stream-to-stream": "~1.3.0",
+        "pull-stringify": "~1.2.2",
+        "rimraf": "^2.4.2",
+        "secret-stack": "^4.1.0",
+        "secure-scuttlebutt": "^18.2.0",
+        "ssb-blobs": "^1.1.4",
+        "ssb-client": "^4.5.7",
+        "ssb-config": "^2.0.0",
+        "ssb-ebt": "^5.1.4",
+        "ssb-friends": "^2.4.0",
+        "ssb-keys": "^7.0.13",
+        "ssb-links": "^3.0.2",
+        "ssb-msgs": "~5.2.0",
+        "ssb-query": "^2.1.0",
+        "ssb-ref": "^2.9.1",
+        "ssb-ws": "^2.1.1",
+        "statistics": "^3.0.0",
+        "stream-to-pull-stream": "^1.6.10",
+        "zerr": "^1.0.0"
       },
       "dependencies": {
         "ip": {
@@ -4306,11 +4194,11 @@
       "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.13.tgz",
       "integrity": "sha512-jDpA1kPJGg+jEUOZGvqksQFGPWIx0aA96HpjU+AqIBKIKzmvZeOq0Lfl/XqVC5jviWTVZZM2B8+NqYR38Blz8A==",
       "requires": {
-        "chloride": "2.2.10",
-        "deep-equal": "1.0.1",
-        "pull-box-stream": "1.0.13",
-        "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.8"
+        "chloride": "^2.2.7",
+        "deep-equal": "~1.0.0",
+        "pull-box-stream": "^1.0.13",
+        "pull-handshake": "^1.1.1",
+        "pull-stream": "^3.4.5"
       }
     },
     "secret-stack": {
@@ -4319,15 +4207,15 @@
       "integrity": "sha512-tCxjylkvEvUqxlWSVALtPMGKGyed225oDf7zoxCOsvj5SaVolUzOaixS07IK74mjcq7D1TvEJ4kofcaTMhQq1w==",
       "requires": {
         "hoox": "0.0.1",
-        "ip": "1.1.5",
-        "map-merge": "1.1.0",
-        "multiserver": "1.12.0",
-        "muxrpc": "6.4.0",
-        "non-private-ip": "1.4.4",
-        "pull-inactivity": "2.1.2",
-        "pull-rate": "1.0.2",
-        "pull-stream": "3.6.8",
-        "stream-to-pull-stream": "1.7.2"
+        "ip": "^1.1.5",
+        "map-merge": "^1.1.0",
+        "multiserver": "^1.11.0",
+        "muxrpc": "^6.4.0",
+        "non-private-ip": "^1.4.3",
+        "pull-inactivity": "~2.1.1",
+        "pull-rate": "^1.0.2",
+        "pull-stream": "^3.4.5",
+        "stream-to-pull-stream": "^1.6.1"
       }
     },
     "secure-scuttlebutt": {
@@ -4335,32 +4223,32 @@
       "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.2.0.tgz",
       "integrity": "sha512-rBK6P3A4MsZI4lrzaf/dbJJDIxuJXO6y3GUeNngb5IJlcagCNJ+zNZcd19rDURfU8tMgOyw+rEwGIs2ExLQTdg==",
       "requires": {
-        "async-write": "2.1.0",
-        "cont": "1.0.3",
-        "deep-equal": "0.2.2",
-        "explain-error": "1.0.4",
+        "async-write": "^2.1.0",
+        "cont": "~1.0.0",
+        "deep-equal": "~0.2.1",
+        "explain-error": "~1.0.1",
         "flumecodec": "0.0.1",
-        "flumedb": "0.4.9",
-        "flumelog-offset": "3.3.1",
-        "flumeview-hashtable": "1.0.4",
-        "flumeview-level": "3.0.5",
-        "flumeview-reduce": "1.3.13",
-        "level": "3.0.2",
-        "level-sublevel": "6.6.5",
-        "ltgt": "2.2.1",
-        "monotonic-timestamp": "0.0.9",
+        "flumedb": "^0.4.2",
+        "flumelog-offset": "^3.3.1",
+        "flumeview-hashtable": "^1.0.3",
+        "flumeview-level": "^3.0.5",
+        "flumeview-reduce": "^1.3.9",
+        "level": "^3.0.1",
+        "level-sublevel": "^6.6.2",
+        "ltgt": "^2.2.0",
+        "monotonic-timestamp": "~0.0.8",
         "obv": "0.0.1",
         "pull-cont": "0.0.0",
-        "pull-level": "2.0.4",
-        "pull-live": "1.0.1",
-        "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.11.1",
-        "ssb-validate": "3.0.10",
-        "typewiselite": "1.0.0"
+        "pull-level": "^2.0.3",
+        "pull-live": "^1.0.1",
+        "pull-notify": "^0.1.0",
+        "pull-paramap": "^1.1.6",
+        "pull-stream": "^3.4.0",
+        "ssb-keys": "^7.0.15",
+        "ssb-msgs": "^5.0.0",
+        "ssb-ref": "^2.0.0",
+        "ssb-validate": "^3.0.1",
+        "typewiselite": "^1.0.0"
       },
       "dependencies": {
         "deep-equal": {
@@ -4395,7 +4283,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "shasum": {
@@ -4404,8 +4292,8 @@
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.5"
+        "json-stable-stringify": "~0.0.0",
+        "sha.js": "~2.4.4"
       }
     },
     "shebang-command": {
@@ -4413,7 +4301,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -4427,10 +4315,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "shellsubstitute": {
@@ -4453,9 +4341,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "simple-mime": {
@@ -4473,8 +4361,8 @@
       "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
       "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
       "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "ip": "^1.1.2",
+        "smart-buffer": "^1.0.4"
       }
     },
     "sodium-browserify": {
@@ -4482,10 +4370,10 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.4.tgz",
       "integrity": "sha512-IYcxKje/uf/c3a7VhZYJLlUxWMcktfbD4AjqHjUD1/VWKjj0Oq5wNbX8wjJOWVO9UhUMqJQiOn2xFbzKWBmy5w==",
       "requires": {
-        "libsodium-wrappers": "0.7.3",
+        "libsodium-wrappers": "^0.7.3",
         "sha.js": "2.4.5",
-        "sodium-browserify-tweetnacl": "0.2.3",
-        "tweetnacl": "0.14.5"
+        "sodium-browserify-tweetnacl": "^0.2.3",
+        "tweetnacl": "^0.14.1"
       }
     },
     "sodium-browserify-tweetnacl": {
@@ -4493,11 +4381,11 @@
       "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
       "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
       "requires": {
-        "chloride-test": "1.2.2",
-        "ed2curve": "0.1.4",
-        "sha.js": "2.4.11",
-        "tweetnacl": "0.14.5",
-        "tweetnacl-auth": "0.3.1"
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^0.14.1",
+        "tweetnacl-auth": "^0.3.0"
       },
       "dependencies": {
         "sha.js": {
@@ -4505,8 +4393,8 @@
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -4522,18 +4410,9 @@
       "integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
       "optional": true,
       "requires": {
-        "ini": "1.3.5",
-        "nan": "2.10.0",
-        "node-gyp-build": "3.4.0"
-      }
-    },
-    "sorted-merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sorted-merge-stream/-/sorted-merge-stream-1.0.1.tgz",
-      "integrity": "sha1-ofRw+m+yU4ZctcTtYlcBPzdID2c=",
-      "requires": {
-        "from2": "2.3.0",
-        "stream-iterate": "1.2.0"
+        "ini": "^1.3.5",
+        "nan": "^2.4.0",
+        "node-gyp-build": "^3.0.0"
       }
     },
     "source-map": {
@@ -4552,10 +4431,10 @@
       "resolved": "https://registry.npmjs.org/ssb-avatar/-/ssb-avatar-0.2.0.tgz",
       "integrity": "sha1-Bs1weV7ljRRi0QCkXGYN8xedOzk=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.11.1"
+        "pull-cat": "^1.1.9",
+        "pull-stream": "^3.4.3",
+        "ssb-msgs": "^5.2.0",
+        "ssb-ref": "^2.3.2"
       }
     },
     "ssb-backlinks": {
@@ -4563,13 +4442,13 @@
       "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-0.7.3.tgz",
       "integrity": "sha512-84s5phSVyZsYV0FTmBJvICPgOMuu8ouzukG8Gz2XtuOui95GBP/G7UIBURgYVS82XA6g9xPA/jf38fsMxid38Q==",
       "requires": {
-        "base64-url": "2.2.0",
-        "deep-equal": "1.0.1",
-        "flumeview-query": "6.2.0",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16",
-        "ssb-ref": "2.11.1",
-        "xtend": "4.0.1"
+        "base64-url": "^2.2.0",
+        "deep-equal": "^1.0.1",
+        "flumeview-query": "^6.2.0",
+        "pull-stream": "^3.6.7",
+        "ssb-keys": "^7.0.14",
+        "ssb-ref": "^2.9.0",
+        "xtend": "^4.0.1"
       }
     },
     "ssb-blobs": {
@@ -4577,13 +4456,13 @@
       "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.5.tgz",
       "integrity": "sha512-DeeInkFU8oN1mYlPVrqrm9tupf6wze4HuowK7N2vv/O+UeSLuYPU1p4HrxSqdAPvUabr0OtvbFA6z1T4nw+9fw==",
       "requires": {
-        "cont": "1.0.3",
-        "level": "3.0.2",
-        "multiblob": "1.13.0",
-        "pull-level": "2.0.4",
-        "pull-notify": "0.1.1",
-        "pull-stream": "3.6.8",
-        "ssb-ref": "2.11.1"
+        "cont": "^1.0.3",
+        "level": "^3.0.0",
+        "multiblob": "^1.12.0",
+        "pull-level": "^2.0.4",
+        "pull-notify": "^0.1.0",
+        "pull-stream": "^3.3.0",
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-client": {
@@ -4591,14 +4470,14 @@
       "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.7.tgz",
       "integrity": "sha512-mEOyMlX6sGEUStU02vdSPD4j9ZRQQe3WCQwZCtgOkkrJpp7ARHxC0dx8ahumyq/vUIYWqQSAHHMD0+R63GmpGg==",
       "requires": {
-        "explain-error": "1.0.4",
-        "multicb": "1.2.2",
-        "multiserver": "1.12.0",
-        "muxrpc": "6.4.0",
-        "pull-hash": "1.0.0",
-        "pull-stream": "3.6.8",
-        "ssb-config": "2.2.0",
-        "ssb-keys": "7.0.16"
+        "explain-error": "^1.0.1",
+        "multicb": "^1.2.1",
+        "multiserver": "^1.7.0",
+        "muxrpc": "^6.4.0",
+        "pull-hash": "^1.0.0",
+        "pull-stream": "^3.6.0",
+        "ssb-config": "^2.2.0",
+        "ssb-keys": "^7.0.13"
       }
     },
     "ssb-config": {
@@ -4606,10 +4485,10 @@
       "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.2.0.tgz",
       "integrity": "sha1-QcrQOKhXWvQGLT/VfTsWe+hbA7w=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "non-private-ip": "1.4.4",
-        "os-homedir": "1.0.2",
-        "rc": "1.2.8"
+        "deep-extend": "^0.4.0",
+        "non-private-ip": "^1.2.1",
+        "os-homedir": "^1.0.1",
+        "rc": "^1.1.6"
       },
       "dependencies": {
         "deep-extend": {
@@ -4624,12 +4503,12 @@
       "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.2.2.tgz",
       "integrity": "sha512-De3dUnmgs/8aYl2fmi/MtJljR9qw1mUmpdM4qeCf+4uniqlNNhfn1Ux+M5A8XYVuI+TD4GkgmIDeZH6miey2kw==",
       "requires": {
-        "base64-url": "2.2.0",
-        "epidemic-broadcast-trees": "6.3.3",
-        "lossy-store": "1.2.3",
-        "pull-stream": "3.6.8",
-        "push-stream-to-pull-stream": "1.0.1",
-        "ssb-ref": "2.11.1"
+        "base64-url": "^2.2.0",
+        "epidemic-broadcast-trees": "^6.3.1",
+        "lossy-store": "^1.2.3",
+        "pull-stream": "^3.5.0",
+        "push-stream-to-pull-stream": "^1.0.0",
+        "ssb-ref": "^2.9.1"
       }
     },
     "ssb-feed": {
@@ -4637,11 +4516,11 @@
       "resolved": "https://registry.npmjs.org/ssb-feed/-/ssb-feed-2.3.0.tgz",
       "integrity": "sha1-uE6OApeg9ZBMTPWiAvdroeB40Ec=",
       "requires": {
-        "cont": "1.0.3",
-        "monotonic-timestamp": "0.0.9",
-        "pull-stream": "3.6.8",
-        "ssb-keys": "7.0.16",
-        "ssb-ref": "2.11.1"
+        "cont": "~1.0.3",
+        "monotonic-timestamp": "~0.0.9",
+        "pull-stream": "^3.4.2",
+        "ssb-keys": "^7.0.0",
+        "ssb-ref": "^2.0.0"
       }
     },
     "ssb-friends": {
@@ -4649,13 +4528,13 @@
       "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-2.4.0.tgz",
       "integrity": "sha1-DUDNlqEvIznJBkqK0dWnE+kcV64=",
       "requires": {
-        "flumeview-reduce": "1.3.13",
-        "graphreduce": "3.0.4",
+        "flumeview-reduce": "^1.3.0",
+        "graphreduce": "^3.0.3",
         "obv": "0.0.1",
-        "pull-cont": "0.1.1",
+        "pull-cont": "^0.1.1",
         "pull-flatmap": "0.0.1",
-        "pull-stream": "3.6.8",
-        "ssb-ref": "2.11.1"
+        "pull-stream": "^3.6.0",
+        "ssb-ref": "^2.7.1"
       },
       "dependencies": {
         "pull-cont": {
@@ -4665,26 +4544,14 @@
         }
       }
     },
-    "ssb-fulltext": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-fulltext/-/ssb-fulltext-1.0.1.tgz",
-      "integrity": "sha1-PizxLFY67dzquIKlPCVVBkr9wnY=",
-      "requires": {
-        "levi": "2.1.7",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.8",
-        "pull-write": "1.1.4",
-        "stream-to-pull-stream": "1.7.2"
-      }
-    },
     "ssb-keys": {
       "version": "7.0.16",
       "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.16.tgz",
       "integrity": "sha512-EhLkRzgF7YaRc47L8YZb+TcxEXZy9DPWCF+vCt5nSNm8Oj+Pz8pBVSOlrLKZVbcAKFjIJhqY32oTjknu3E1KVQ==",
       "requires": {
-        "chloride": "2.2.10",
-        "mkdirp": "0.5.1",
-        "private-box": "0.2.1"
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.2.1"
       }
     },
     "ssb-links": {
@@ -4692,10 +4559,10 @@
       "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.3.tgz",
       "integrity": "sha512-x09ShIMjwvdZI7aDZm8kc1v5YCGZa9ulCOoxrf/RYJ98s5gbTfO9CBCzeMBAeQ5kRwSuKjiOxJHdeEBkj4Y6hw==",
       "requires": {
-        "flumeview-query": "6.2.0",
-        "map-filter-reduce": "2.2.1",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0"
+        "flumeview-query": "^6.0.0",
+        "map-filter-reduce": "^2.0.0",
+        "pull-stream": "^3.1.0",
+        "ssb-msgs": "^5.2.0"
       }
     },
     "ssb-markdown": {
@@ -4703,10 +4570,10 @@
       "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-3.6.0.tgz",
       "integrity": "sha512-WaI/s6Zbq9EBAE9CD2OnPMn1U7Wce3HBK3EZN2qfnjIEkirL/oj8Wz92sBYyyV+tae1aJJRTV7/PFbT5YfNk+g==",
       "requires": {
-        "emoji-named-characters": "1.0.2",
-        "ssb-marked": "0.7.4",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.11.1"
+        "emoji-named-characters": "^1.0.2",
+        "ssb-marked": "^0.7.3",
+        "ssb-msgs": "^5.2.0",
+        "ssb-ref": "^2.3.0"
       }
     },
     "ssb-marked": {
@@ -4719,8 +4586,8 @@
       "resolved": "https://registry.npmjs.org/ssb-mentions/-/ssb-mentions-0.5.0.tgz",
       "integrity": "sha512-tXFr8CSNPKwCkRftm8Z0H5mXhfHLNhwNgo7PdR8GobxCSSoaHXfxsGbAJVKDl/kCkgL92nPidS3SlsFqtjFE7Q==",
       "requires": {
-        "ssb-marked": "0.7.4",
-        "ssb-ref": "2.11.1"
+        "ssb-marked": "^0.7.0",
+        "ssb-ref": "^2.11.0"
       }
     },
     "ssb-msgs": {
@@ -4728,7 +4595,7 @@
       "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
       "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
       "requires": {
-        "ssb-ref": "2.11.1"
+        "ssb-ref": "^2.0.0"
       }
     },
     "ssb-query": {
@@ -4736,9 +4603,9 @@
       "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.1.0.tgz",
       "integrity": "sha512-4QWvjSrSIon9qyhPHrqOeA/dp6NR7b11BtXKhJg/Di2r7/nBLGAj2RzUonfTfs3LlPHZdFWXowhhJREUAmUZug==",
       "requires": {
-        "explain-error": "1.0.4",
-        "flumeview-query": "6.2.0",
-        "pull-stream": "3.6.8"
+        "explain-error": "^1.0.1",
+        "flumeview-query": "^6.0.0",
+        "pull-stream": "^3.6.2"
       }
     },
     "ssb-ref": {
@@ -4746,8 +4613,8 @@
       "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.11.1.tgz",
       "integrity": "sha512-K3L9hJ1v0HrH8abtEKiBkdeabHVaws+CS81mZqUfhR84i0dlYhiIIDwqeLxUj/1mLcsZPF3gMKPsFCUr7UAdMA==",
       "requires": {
-        "ip": "1.1.5",
-        "is-valid-domain": "0.0.5"
+        "ip": "^1.1.3",
+        "is-valid-domain": "~0.0.1"
       }
     },
     "ssb-search": {
@@ -4755,10 +4622,10 @@
       "resolved": "https://registry.npmjs.org/ssb-search/-/ssb-search-1.1.2.tgz",
       "integrity": "sha512-k7CCfdugGYvNMZekGJXcCYuCdf7MEP+bBZr+AsZO5KqaNb4K9CuP6W1wGoKH6vkparhaCKc85jO46EbWsEoVDQ==",
       "requires": {
-        "flumeview-search": "1.0.4",
-        "pull-cont": "0.1.1",
-        "pull-stream": "3.6.8",
-        "ssb-msgs": "5.2.0"
+        "flumeview-search": "^1.0.0",
+        "pull-cont": "^0.1.1",
+        "pull-stream": "^3.6.7",
+        "ssb-msgs": "^5.2.0"
       },
       "dependencies": {
         "pull-cont": {
@@ -4773,7 +4640,7 @@
       "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-3.0.10.tgz",
       "integrity": "sha512-9wJE1i+4vW/F/TYQQl15BVoiZb9kaqIRBhl2I/TXyhjngfx/yBzXFAuiXhaiDfqJ3YnUXzY4JMUSx0gIvpePnQ==",
       "requires": {
-        "ssb-ref": "2.11.1"
+        "ssb-ref": "^2.6.2"
       }
     },
     "ssb-ws": {
@@ -4781,13 +4648,13 @@
       "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-2.1.1.tgz",
       "integrity": "sha512-1fK/jXI6lKZadRJDr49t+6yMmWynp6PFrADs3Whmy8IslnYGl83ujhlpRIBvCn1EuVHjV7yLsIiJ8a0X2Kg0DQ==",
       "requires": {
-        "emoji-server": "1.0.0",
-        "multiblob-http": "0.4.2",
-        "multiserver": "1.12.0",
-        "muxrpc": "6.4.0",
-        "pull-box-stream": "1.0.13",
-        "ssb-ref": "2.11.1",
-        "stack": "0.1.0"
+        "emoji-server": "^1.0.0",
+        "multiblob-http": "^0.4.1",
+        "multiserver": "^1.2.0",
+        "muxrpc": "^6.3.3",
+        "pull-box-stream": "^1.0.13",
+        "ssb-ref": "^2.3.0",
+        "stack": "^0.1.0"
       }
     },
     "stack": {
@@ -4800,19 +4667,14 @@
       "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
       "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
     },
-    "stemmer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-0.1.4.tgz",
-      "integrity": "sha1-uQnnMArzdUmiEAm8c1KG9Y8qyMs="
-    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-combiner2": {
@@ -4821,8 +4683,8 @@
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.6"
+        "duplexer2": "~0.1.0",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-http": {
@@ -4831,26 +4693,12 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
-    },
-    "stream-iterate": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.2.0.tgz",
-      "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
-      "requires": {
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
     "stream-splicer": {
       "version": "2.0.0",
@@ -4858,8 +4706,8 @@
       "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-to-pull-stream": {
@@ -4867,8 +4715,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "3.0.0",
-        "pull-stream": "3.6.8"
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
       }
     },
     "string-width": {
@@ -4876,9 +4724,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string.prototype.trim": {
@@ -4886,9 +4734,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {
@@ -4896,7 +4744,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
@@ -4904,10 +4752,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "1.1.2",
-        "character-entities-legacy": "1.1.2",
-        "is-alphanumerical": "1.0.2",
-        "is-hexadecimal": "1.0.2"
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "strip-ansi": {
@@ -4915,13 +4763,8 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -4934,99 +4777,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
-      }
-    },
-    "sublevelup": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/sublevelup/-/sublevelup-4.0.0.tgz",
-      "integrity": "sha1-2lAWmqcR6BU0WoeJDmhnXZYtvFU=",
-      "requires": {
-        "levelup": "1.3.9",
-        "prefixdown": "1.4.0",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "requires": {
-            "errno": "0.1.7"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
+        "minimist": "^1.1.0"
       }
     },
     "supports-color": {
@@ -5040,7 +4791,7 @@
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2"
+        "acorn-node": "^1.2.0"
       }
     },
     "tape": {
@@ -5048,19 +4799,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
       "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.3",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.3",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.6.0",
-        "resolve": "1.7.1",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.2",
+        "has": "~1.0.3",
+        "inherits": "~2.0.3",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.7.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "glob": {
@@ -5068,12 +4819,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -5083,10 +4834,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.1"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       },
       "dependencies": {
         "pump": {
@@ -5094,8 +4845,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -5105,13 +4856,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "text-table": {
@@ -5128,9 +4879,10 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "timers-browserify": {
@@ -5139,7 +4891,7 @@
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
-        "process": "0.11.10"
+        "process": "~0.11.0"
       }
     },
     "to-arraybuffer": {
@@ -5158,7 +4910,7 @@
       "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
       "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
       "requires": {
-        "vfile": "1.4.0"
+        "vfile": "^1.0.0"
       }
     },
     "trim": {
@@ -5187,7 +4939,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -5200,7 +4952,7 @@
       "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "0.x.x"
       }
     },
     "typedarray": {
@@ -5208,17 +4960,12 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "typedarray-to-buffer": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-1.0.4.tgz",
-      "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
-    },
     "typewise": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
       "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
       "requires": {
-        "typewise-core": "1.2.0"
+        "typewise-core": "^1.2.0"
       }
     },
     "typewise-core": {
@@ -5253,10 +5000,10 @@
       "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
       "dev": true,
       "requires": {
-        "acorn-node": "1.5.2",
-        "get-assigned-identifiers": "1.2.0",
-        "simple-concat": "1.0.0",
-        "xtend": "4.0.1"
+        "acorn-node": "^1.3.0",
+        "get-assigned-identifiers": "^1.2.0",
+        "simple-concat": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "unherit": {
@@ -5264,8 +5011,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "unified": {
@@ -5273,12 +5020,12 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
       "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
       "requires": {
-        "attach-ware": "1.1.1",
-        "bail": "1.0.3",
-        "extend": "3.0.2",
-        "unherit": "1.1.1",
-        "vfile": "1.4.0",
-        "ware": "1.3.0"
+        "attach-ware": "^1.0.0",
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "unherit": "^1.0.4",
+        "vfile": "^1.0.0",
+        "ware": "^1.3.0"
       }
     },
     "unist-util-is": {
@@ -5291,7 +5038,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
       "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
       "requires": {
-        "unist-util-visit-parents": "2.0.1"
+        "unist-util-visit-parents": "^2.0.0"
       }
     },
     "unist-util-visit-parents": {
@@ -5299,7 +5046,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
       "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
       "requires": {
-        "unist-util-is": "2.1.2"
+        "unist-util-is": "^2.1.2"
       }
     },
     "untildify": {
@@ -5307,7 +5054,7 @@
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "url": {
@@ -5333,7 +5080,7 @@
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util": {
@@ -5360,7 +5107,7 @@
       "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
       "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
       "requires": {
-        "to-vfile": "1.0.0"
+        "to-vfile": "^1.0.0"
       }
     },
     "vfile-find-up": {
@@ -5368,7 +5115,7 @@
       "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
       "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
       "requires": {
-        "to-vfile": "1.0.0"
+        "to-vfile": "^1.0.0"
       }
     },
     "vfile-reporter": {
@@ -5376,13 +5123,13 @@
       "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
       "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
       "requires": {
-        "chalk": "1.1.3",
-        "log-symbols": "1.0.2",
-        "plur": "2.1.2",
-        "repeat-string": "1.6.1",
-        "string-width": "1.0.2",
-        "text-table": "0.2.0",
-        "vfile-sort": "1.0.0"
+        "chalk": "^1.1.0",
+        "log-symbols": "^1.0.2",
+        "plur": "^2.0.0",
+        "repeat-string": "^1.5.0",
+        "string-width": "^1.0.0",
+        "text-table": "^0.2.0",
+        "vfile-sort": "^1.0.0"
       }
     },
     "vfile-sort": {
@@ -5406,7 +5153,7 @@
       "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
       "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
       "requires": {
-        "wrap-fn": "0.1.5"
+        "wrap-fn": "^0.1.0"
       }
     },
     "which": {
@@ -5414,13 +5161,8 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
-    },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -5432,7 +5174,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "word-wrap": {
@@ -5445,15 +5187,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
     },
     "wrap-fn": {
       "version": "0.1.5",
@@ -5473,8 +5206,8 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
       "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xtend": {
@@ -5482,78 +5215,10 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
-    "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-      "requires": {
-        "cliui": "4.1.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-      "requires": {
-        "camelcase": "4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        }
-      }
     },
     "zerr": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "decent-ws": "1.0.4",
     "deep-extend": "^0.6.0",
     "diff": "^3.5.0",
-    "emoji-server": "^1.0.0",
     "human-time": "0.0.1",
     "hyperfile": "^2.0.0",
     "hyperloadmore": "^1.1.0",
@@ -47,15 +46,12 @@
     "ssb-ebt": "^5.1.5",
     "ssb-feed": "^2.3.0",
     "ssb-friends": "^2.4.0",
-    "ssb-fulltext": "^1.0.1",
     "ssb-keys": "^7.0.16",
     "ssb-links": "^3.0.3",
     "ssb-markdown": "^3.6.0",
     "ssb-mentions": "^0.5.0",
     "ssb-ref": "^2.11.1",
     "ssb-search": "^1.0.1",
-    "ssb-validate": "^3.0.10",
-    "visualize-buffer": "0.0.1",
-    "yargs": "^11.0.0"
+    "visualize-buffer": "0.0.1"
   }
 }


### PR DESCRIPTION
I've removed a handful of unused dependencies, which means we don't need the old leveldown and this now works on Node 10. :raised_hands: 

I noticed that `./query/index.js` requires both `flumeview-query` and `explain-error`, but I'm not sure whether/where that file is used for mvd. Should I add those dependencies to `package*.json`, or just leave as-is?

Thanks!